### PR TITLE
Include PR author in the votes

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -185,9 +185,9 @@ def check_pull_request(repository, pull_request, commentOnIssue):
     author = pull_request.user.login
     possible_reviewers = {contributor: contributors[contributor] for contributor in contributors if contributor != author}
 
-    # Sum of total contriution without the author of the pull request
-    votes_total = sum(possible_reviewers[possible_reviewer] for possible_reviewer in possible_reviewers)
-    votes = 0
+    # Sum of total number of commits, initialize votes with the authors weight
+    votes_total = sum(commit_activity.total for commit_activity in repository.get_stats_commit_activity())
+    votes = contributors[author]
 
     reviews = get_reviews(repository, pull_request.number)
     for review in reviews:

--- a/src/server.py
+++ b/src/server.py
@@ -186,7 +186,7 @@ def check_pull_request(repository, pull_request, commentOnIssue):
     possible_reviewers = {contributor: contributors[contributor] for contributor in contributors if contributor != author}
 
     # Sum of total number of commits, initialize votes with the authors weight
-    votes_total = sum(commit_activity.total for commit_activity in repository.get_stats_commit_activity())
+    votes_total = sum(contributors[contributor] for contributor in contributors)
     votes = contributors[author]
 
     reviews = get_reviews(repository, pull_request.number)
@@ -229,6 +229,7 @@ def check_pull_request(repository, pull_request, commentOnIssue):
         pull_request.merge()
 
 def check_pull_requests():
+    print(datetime.now())
     token = os.getenv('TOKEN')
     github_client = github.Github(token)
     repositories = ['tooangel/democratic-collaboration', 'tooangel/screeps']


### PR DESCRIPTION
`votes_total` is the total number of commits.
`votes` is initialized with the PR author weight.

The previous calculation ran into the issue, that low weight
contributions could prolong PR merges for a couple of time.
A PR of a height weigted contributor should reflect their weight.

Addresses #10